### PR TITLE
Minor fix for build on ARM systems

### DIFF
--- a/src/klogctl.rs
+++ b/src/klogctl.rs
@@ -407,7 +407,7 @@ pub fn safely_wrapped_klogctl(klogtype: KLogType, buf_u8: &mut [u8]) -> Result<u
     // and typecast it (very dangerously) to i8
     // fortunately it's all one-byte long so
     // should be reasonably okay.
-    let buf_i8 = buf_u8.as_mut_ptr() as *mut i8;
+    let buf_cchar = buf_u8.as_mut_ptr() as *mut libc::c_char;
 
     let buflen = match libc::c_int::try_from(buf_u8.len()) {
         Ok(i) => i,
@@ -420,7 +420,7 @@ pub fn safely_wrapped_klogctl(klogtype: KLogType, buf_u8: &mut [u8]) -> Result<u
         }
     };
 
-    let response_cint: libc::c_int = unsafe { klogctl(klt, buf_i8, buflen) };
+    let response_cint: libc::c_int = unsafe { klogctl(klt, buf_cchar, buflen) };
 
     if response_cint < 0 {
         let err = errno();


### PR DESCRIPTION
Change `i8` to `libc::c_char` to allow rmesg to build on arm because unfortunately `char` is a u8 on many arm systems.

This fix prevents the following build error on ARM systems:
```
error[E0308]: mismatched types
   --> src/klogctl.rs:423:60
    |
423 |     let response_cint: libc::c_int = unsafe { klogctl(klt, buf_i8, buflen) };
    |                                                            ^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*mut u8`
               found raw pointer `*mut i8`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `rmesg`
```