### PR TITLE
prevent panic when run rmesg without sudo permission

### DIFF
--- a/src/klogctl.rs
+++ b/src/klogctl.rs
@@ -89,7 +89,7 @@ lazy_static! {
     .unwrap();
 }
 
-/// While reading the kernel log buffer is very useful in and of itself (expecially when running the CLI),
+/// While reading the kernel log buffer is very useful in and of itself (especially when running the CLI),
 /// a lot more value is unlocked when it can be tailed line-by-line.
 ///
 /// This struct provides the facilities to do that. It implements an iterator to easily iterate
@@ -359,7 +359,7 @@ pub fn entries_from_lines(all_lines: &str) -> Result<Vec<Entry>, EntryParsingErr
         .map(|line| entry_from_line(line))
         .collect();
 
-    Ok(entry_results?)
+    entry_results
 }
 
 pub fn entry_from_line(line: &str) -> Result<Entry, EntryParsingError> {

--- a/src/kmsgfile.rs
+++ b/src/kmsgfile.rs
@@ -49,7 +49,7 @@ lazy_static! {
     .unwrap();
 }
 
-/// While reading the kernel log buffer is very useful in and of itself (expecially when running the CLI),
+/// While reading the kernel log buffer is very useful in and of itself (especially when running the CLI),
 /// a lot more value is unlocked when it can be tailed line-by-line.
 ///
 /// This struct provides the facilities to do that. It implements an iterator to easily iterate
@@ -119,7 +119,7 @@ impl Iterator for KMsgEntriesIter {
     }
 }
 
-/// While reading the kernel log buffer is very useful in and of itself (expecially when running the CLI),
+/// While reading the kernel log buffer is very useful in and of itself (especially when running the CLI),
 /// a lot more value is unlocked when it can be tailed line-by-line.
 ///
 /// This struct provides the facilities to do that. It implements an iterator to easily iterate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,10 @@ pub fn log_entries(b: Backend, clear: bool) -> Result<Vec<entry::Entry>, error::
                     "Falling back from device file to klogctl syscall due to error: {}",
                     s
                 );
+                if std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM) {
+                    eprintln!("Help: run rmesg with sudo");
+                    return Ok(vec![]);
+                }
                 klogctl::klog(clear)
             }
             Err(e) => Err(e),


### PR DESCRIPTION
run rmesg without sudo would panic is not user-friendly

```
Falling back from device file to klogctl syscall due to error: Unable to open file /dev/kmsg: Operation not permitted (os error 1)
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: InternalError("Request (SyslogActionSizeBuffer) to klogctl failed. errno=Operation not permitted")', /home/w/.cargo/registry/src/github.com-1ecc6299db9ec823/rmesg-1.0.14/src/main.rs:38:68
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted (core dumped)
```