### PR TITLE
 Ensure 'sudo' hint is printed when rmest is run without root

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -39,10 +39,7 @@ impl Display for RMesgError {
                     "Failed to add a Duration to SystemTime".to_owned(),
                 Self::KLogTimestampsDisabled => "Kernel Log timestamps are disabled".to_owned(),
                 Self::DevKMsgFileOpenError(s) => s.to_owned(),
-                Self::OperationNotPermitted(s) => format!(
-                    "OperationNotPermitted: {}\nHint: Try running with 'sudo' or as root.",
-                    s
-                ),
+                Self::OperationNotPermitted(s) => format!("OperationNotPermitted: {}", s),
             }
         )
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,7 @@ pub enum RMesgError {
     EntryParsingError(String),
     UnableToObtainElapsedTime(SystemTimeError),
     DevKMsgFileOpenError(String),
+    OperationNotPermitted(String),
 }
 impl Error for RMesgError {}
 impl Display for RMesgError {
@@ -38,6 +39,10 @@ impl Display for RMesgError {
                     "Failed to add a Duration to SystemTime".to_owned(),
                 Self::KLogTimestampsDisabled => "Kernel Log timestamps are disabled".to_owned(),
                 Self::DevKMsgFileOpenError(s) => s.to_owned(),
+                Self::OperationNotPermitted(s) => format!(
+                    "OperationNotPermitted: {}\nHint: Try running with 'sudo' or as root.",
+                    s
+                ),
             }
         )
     }

--- a/src/klogctl.rs
+++ b/src/klogctl.rs
@@ -424,10 +424,15 @@ pub fn safely_wrapped_klogctl(klogtype: KLogType, buf_u8: &mut [u8]) -> Result<u
 
     if response_cint < 0 {
         let err = errno();
-        return Err(RMesgError::InternalError(format!(
-            "Request ({}) to klogctl failed. errno={}",
-            klogtype, err
-        )));
+
+        if err.0 == libc::EPERM {
+            return Err(RMesgError::OperationNotPermitted(format!("{}", klogtype)));
+        } else {
+            return Err(RMesgError::InternalError(format!(
+                "Request ({}) to klogctl failed. errno={}",
+                klogtype, err
+            )));
+        }
     }
 
     let response = match usize::try_from(response_cint) {

--- a/src/kmsgfile.rs
+++ b/src/kmsgfile.rs
@@ -74,10 +74,17 @@ impl KMsgEntriesIter {
         let file = match stdfs::File::open(path) {
             Ok(fc) => fc,
             Err(e) => {
-                return Err(RMesgError::DevKMsgFileOpenError(format!(
-                    "Unable to open file {}: {}",
-                    path, e
-                )))
+                if e.raw_os_error() == Some(libc::EPERM) {
+                    return Err(RMesgError::OperationNotPermitted(format!(
+                        "Open File {}",
+                        path
+                    )));
+                } else {
+                    return Err(RMesgError::DevKMsgFileOpenError(format!(
+                        "Unable to open file {}: {}",
+                        path, e
+                    )));
+                }
             }
         };
 
@@ -148,10 +155,17 @@ impl KMsgEntriesStream {
         let file = match tokiofs::File::open(path).await {
             Ok(fc) => fc,
             Err(e) => {
-                return Err(RMesgError::DevKMsgFileOpenError(format!(
-                    "Unable to open file {}: {}",
-                    path, e
-                )))
+                if e.raw_os_error() == Some(libc::EPERM) {
+                    return Err(RMesgError::OperationNotPermitted(format!(
+                        "Open File {}",
+                        path
+                    )));
+                } else {
+                    return Err(RMesgError::DevKMsgFileOpenError(format!(
+                        "Unable to open file {}: {}",
+                        path, e
+                    )));
+                }
             }
         };
 
@@ -209,7 +223,7 @@ pub fn kmsg_raw(file_override: Option<String>) -> Result<String, RMesgError> {
     let file = match stdfs::File::open(path) {
         Ok(fc) => fc,
         Err(e) => {
-            if std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM) {
+            if e.raw_os_error() == Some(libc::EPERM) {
                 return Err(RMesgError::OperationNotPermitted(format!(
                     "Open File {}",
                     path
@@ -229,10 +243,17 @@ pub fn kmsg_raw(file_override: Option<String>) -> Result<String, RMesgError> {
     match noblock_file.read_available_to_string(&mut file_contents) {
         Ok(_) => {}
         Err(e) => {
-            return Err(RMesgError::DevKMsgFileOpenError(format!(
-                "Unable to read from file {}: {}",
-                path, e
-            )))
+            if e.raw_os_error() == Some(libc::EPERM) {
+                return Err(RMesgError::OperationNotPermitted(format!(
+                    "Read from File {}",
+                    path
+                )));
+            } else {
+                return Err(RMesgError::DevKMsgFileOpenError(format!(
+                    "Unable to read from file {}: {}",
+                    path, e
+                )));
+            }
         }
     }
 

--- a/src/kmsgfile.rs
+++ b/src/kmsgfile.rs
@@ -209,10 +209,17 @@ pub fn kmsg_raw(file_override: Option<String>) -> Result<String, RMesgError> {
     let file = match stdfs::File::open(path) {
         Ok(fc) => fc,
         Err(e) => {
-            return Err(RMesgError::DevKMsgFileOpenError(format!(
-                "Unable to open file {}: {}",
-                path, e
-            )))
+            if std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM) {
+                return Err(RMesgError::OperationNotPermitted(format!(
+                    "Open File {}",
+                    path
+                )));
+            } else {
+                return Err(RMesgError::DevKMsgFileOpenError(format!(
+                    "Unable to open file {}: {}",
+                    path, e
+                )));
+            }
         }
     };
 
@@ -223,7 +230,7 @@ pub fn kmsg_raw(file_override: Option<String>) -> Result<String, RMesgError> {
         Ok(_) => {}
         Err(e) => {
             return Err(RMesgError::DevKMsgFileOpenError(format!(
-                "Unable to open file {}: {}",
+                "Unable to read from file {}: {}",
                 path, e
             )))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,6 @@ pub fn log_entries(b: Backend, clear: bool) -> Result<Vec<entry::Entry>, error::
                     "Falling back from device file to klogctl syscall due to error: {}",
                     s
                 );
-                if std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM) {
-                    eprintln!("Help: run rmesg with sudo");
-                    return Ok(vec![]);
-                }
                 klogctl::klog(clear)
             }
             Err(e) => Err(e),


### PR DESCRIPTION
 Ensure 'sudo' hint is printed when rmest is run without root

In the previous change this was fixed, however, the hint printing
was embedded in lib.rs which would be inherited by other programs
that may embed rmesg.

This change gives it a proper enum in
RMesgError::OperationNotPermitted and allows callers to know when
an operation has failed due to permissions, allowing
every consumer to implement their appropriate logic to surface
that error.